### PR TITLE
Refactor tests to run in SQLAlchemy transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
     apt-get update && apt-get -y install postgresql-client-12
 
 COPY pyproject.toml poetry.lock ./
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false

--- a/app/db/migrations/env.py
+++ b/app/db/migrations/env.py
@@ -51,7 +51,6 @@ def do_run_migrations(connection):
     )
 
     with context.begin_transaction():
-        # connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {TENANT_SCHEMA_NAME};"))
         context.run_migrations()
 
 async def run_migrations_online():
@@ -78,10 +77,6 @@ async def run_migrations_online():
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)
-        # context.configure(connection=connection, target_metadata=target_metadata)
-
-        # with context.begin_transaction():
-        #     context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/tests/app/api/routes/test_coupons.py
+++ b/tests/app/api/routes/test_coupons.py
@@ -8,7 +8,7 @@ from starlette import status
 from app.db.repositories.coupons import CouponsRepository
 from app.models.schema.coupons import InCouponSchema
 
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 async def test_coupon_create(

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -2,7 +2,7 @@ import pytest
 from httpx import AsyncClient
 from starlette import status
 
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 async def test_main(async_client: AsyncClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,38 +1,114 @@
-import asyncio
-from typing import AsyncGenerator, Generator, Callable
-
-import pytest
 from fastapi import FastAPI
-
+from sqlalchemy.engine.base import Transaction
+from sqlalchemy.orm.session import Session
+from sqlalchemy import event, insert
+from typing import Any, AsyncGenerator, Callable
+import asyncio
+import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.db.base import Base
-from app.db.session import async_session, engine
+from sqlalchemy_utils import database_exists, create_database, drop_database
+from app.core.config import settings
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    """
+    Make AnyIO work in tests
+    """
+    return 'asyncio'
 
 
 @pytest.fixture(scope="session")
-def event_loop(request) -> Generator:
-    """Create an instance of the default event loop for each test case."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
+def event_loop():
+    """
+    Session scoped event_loop fixture is required for testing with SQLAlchemy async + transactions
+    details here: https://github.com/igortg/pytest-async-sqlalchemy#providing-a-session-scoped-event-loop
+    """
+
+    loop = asyncio.new_event_loop()
     yield loop
     loop.close()
 
 
-@pytest.fixture()
-async def db_session() -> AsyncSession:
-    async with engine.begin() as connection:
-        await connection.run_sync(Base.metadata.drop_all)
-        await connection.run_sync(Base.metadata.create_all)
-        async with async_session(bind=connection) as session:
-            yield session
-            await session.flush()
-            await session.rollback()
+@pytest.fixture(scope='session')
+def test_db_suffix() -> str:
+    """
+    
+    """
+    return '_test'
 
+
+@pytest.fixture(scope="session", autouse=True)
+def test_database(test_db_suffix):
+    """
+    Create an empty test database, yield and destroy it once the tests are complete
+    """
+
+    sync_database_url = settings.DATABASE_URL + test_db_suffix
+
+    if not database_exists(sync_database_url):
+        create_database(sync_database_url)
+    yield
+    drop_database(sync_database_url)
+
+
+@pytest.fixture(scope='session')
+def db_uri(test_db_suffix):
+    return settings.async_database_url + test_db_suffix
+
+
+@pytest.fixture(autouse=True, scope="session")
+def apply_migrations(test_database, db_uri) -> None:
+    """
+    Apply migrations
+    """
+    import alembic.config
+    alembic.config.main(argv=["-x", f"dbPath={db_uri}", "upgrade", "head"])
+
+
+@pytest.fixture
+def async_engine(apply_migrations, db_uri):
+    return create_async_engine(db_uri, echo=True)
+
+
+@pytest.fixture
+async def connection(async_engine):
+    connection = await async_engine.connect()
+    yield connection
+    if not connection.closed:
+        await connection.close()
+
+
+@pytest.fixture
+async def db_session(connection):
+    """Returns an AsyncSession wrapped in a transaction"""
+    transaction = await connection.begin()
+    await connection.begin_nested()
+
+    session = AsyncSession(bind=connection, expire_on_commit=False, future=True)
+
+    @event.listens_for(session.sync_session, "after_transaction_end")
+    def end_savepoint(session: Session, transaction: Transaction) -> None:
+        if connection.closed:
+            return
+
+        if not connection.in_nested_transaction():
+            connection.sync_connection.begin_nested()
+
+    yield session
+
+    if session.in_transaction():
+        await transaction.rollback()
 
 @pytest.fixture()
 def override_get_db(db_session: AsyncSession) -> Callable:
     async def _override_get_db():
-        yield db_session
+        return db_session
 
     return _override_get_db
 


### PR DESCRIPTION
This PR alters conftest.py to do the database setup once at the start of the test run, then execute each test case inside a transaction that is rolled back automatically at the end of each test. This speeds things up a fair bit.

Also, a dedicated test database is created and destroyed for each test run, which avoids clearing data in the local db

Finally - database tables are created by explicitly running the alembic migrations rather than via the metadata. This ensures that migrations are also tested.

Updated a few dependencies along the way